### PR TITLE
Implement execute_in function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Features
 
+-   Implement execute_in function
+-   Introduce working directory parameter in execute FFI functions
 -   Handle abort reasons
 -   Implement Gleam cwd function
 -   Implement Elixir cwd function
@@ -15,6 +17,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 -   Implement Gleam execute function
 -   Implement Elixir execute function
 -   Implement JavaScript execute function
+
+### Refactor
+
+-   Return output without removing trimming whitespace
+-   Drop Bun support
 
 ### Miscellaneous Tasks
 

--- a/src/gleamyshell.gleam
+++ b/src/gleamyshell.gleam
@@ -21,22 +21,15 @@ pub fn execute(
   command command: String,
   args args: List(String),
 ) -> Result(String, CommandError) {
-  case execute_ffi(command, args) {
-    Ok(output) ->
-      output
-      |> string.trim()
-      |> Ok()
-    Error(#(output, Some(exit_code))) ->
-      output
-      |> string.trim()
-      |> Failure(exit_code)
-      |> Error()
-    Error(#(reason, None)) ->
-      reason
-      |> to_abort_reason()
-      |> Abort()
-      |> Error()
-  }
+  internal_execute(command, args, None)
+}
+
+pub fn execute_in(
+  command command: String,
+  args args: List(String),
+  working_directory working_directory: String,
+) -> Result(String, CommandError) {
+  internal_execute(command, args, Some(working_directory))
 }
 
 pub fn cwd() -> Option(String) {
@@ -66,11 +59,35 @@ fn to_abort_reason(reason: String) -> AbortReason {
   }
 }
 
+fn internal_execute(
+  command: String,
+  args: List(String),
+  working_directory: Option(String),
+) -> Result(String, CommandError) {
+  case execute_ffi(command, args, working_directory) {
+    Ok(output) ->
+      output
+      |> string.trim()
+      |> Ok()
+    Error(#(output, Some(exit_code))) ->
+      output
+      |> string.trim()
+      |> Failure(exit_code)
+      |> Error()
+    Error(#(reason, None)) ->
+      reason
+      |> to_abort_reason()
+      |> Abort()
+      |> Error()
+  }
+}
+
 @external(erlang, "Elixir.GleamyShell", "execute")
 @external(javascript, "./gleamyshell_ffi.mjs", "execute")
 fn execute_ffi(
   command: String,
   args: List(String),
+  working_directory: Option(String),
 ) -> Result(String, #(String, Option(Int)))
 
 @external(erlang, "Elixir.GleamyShell", "cwd")

--- a/src/gleamyshell.gleam
+++ b/src/gleamyshell.gleam
@@ -33,13 +33,7 @@ pub fn execute_in(
 }
 
 pub fn cwd() -> Option(String) {
-  case cwd_ffi() {
-    Some(path) ->
-      path
-      |> string.trim()
-      |> Some()
-    None -> None
-  }
+  cwd_ffi()
 }
 
 fn to_abort_reason(reason: String) -> AbortReason {
@@ -67,11 +61,9 @@ fn internal_execute(
   case execute_ffi(command, args, working_directory) {
     Ok(output) ->
       output
-      |> string.trim()
       |> Ok()
     Error(#(output, Some(exit_code))) ->
       output
-      |> string.trim()
       |> Failure(exit_code)
       |> Error()
     Error(#(reason, None)) ->

--- a/src/gleamyshell_ffi.ex
+++ b/src/gleamyshell_ffi.ex
@@ -1,7 +1,13 @@
 defmodule GleamyShell do
-  def execute(command, args) do
+  def execute(command, args, working_directory) do
+    opts =
+      case working_directory do
+        {:some, dir} -> [{:stderr_to_stdout, true}, {:cd, dir}]
+        :none -> [{:stderr_to_stdout, true}]
+      end
+
     try do
-      {output, exit_code} = System.cmd(command, args, stderr_to_stdout: true)
+      {output, exit_code} = System.cmd(command, args, opts)
 
       case exit_code do
         0 -> {:ok, output}

--- a/src/gleamyshell_ffi.mjs
+++ b/src/gleamyshell_ffi.mjs
@@ -1,13 +1,15 @@
 import child_process from "node:child_process"
 import process from "node:process"
 import { Ok, Error } from "./gleam.mjs"
-import { Some, None } from "../gleam_stdlib/gleam/option.mjs"
+import { Some, None, is_some, unwrap } from "../gleam_stdlib/gleam/option.mjs"
 
-export function execute(command, args) {
+export function execute(command, args, workingDirectory) {
+    const options = is_some(workingDirectory) ? { cwd: unwrap(workingDirectory) } : {}
+
     let result = {}
 
     try {
-        result = child_process.spawnSync(command, args.toArray())
+        result = child_process.spawnSync(command, args.toArray(), options)
     } catch {}
 
     return toResult(result)

--- a/test/gleamyshell_test.gleam
+++ b/test/gleamyshell_test.gleam
@@ -52,19 +52,6 @@ pub fn execute_tests() {
           _ -> panic
         }
       }),
-      it("returns exit code 126", fn() {
-        let failure =
-          gleamyshell.execute("/bin/sh", ["ls"])
-          |> expect.to_be_error()
-
-        case failure {
-          Failure(output, exit_code) -> {
-            expect.to_equal(exit_code, 126)
-            expect_to_contain(output, "cannot execute binary file")
-          }
-          _ -> panic
-        }
-      }),
     ]),
   ])
 }
@@ -108,19 +95,6 @@ pub fn execute_in_tests() {
           Failure(output, exit_code) -> {
             expect.to_equal(exit_code, 127)
             expect_to_contain(output, "not found")
-          }
-          _ -> panic
-        }
-      }),
-      it("returns exit code 126", fn() {
-        let failure =
-          gleamyshell.execute_in("/bin/sh", ["ls"], "/usr/bin")
-          |> expect.to_be_error()
-
-        case failure {
-          Failure(output, exit_code) -> {
-            expect.to_equal(exit_code, 126)
-            expect_to_contain(output, "cannot execute binary file")
           }
           _ -> panic
         }

--- a/test/gleamyshell_test.gleam
+++ b/test/gleamyshell_test.gleam
@@ -17,7 +17,7 @@ pub fn execute_tests() {
 
         gleamyshell.execute("echo", [output])
         |> expect.to_be_ok()
-        |> expect.to_equal(output)
+        |> expect.to_equal(output <> "\n")
       }),
     ]),
     describe("failed commands", [
@@ -77,7 +77,7 @@ pub fn execute_in_tests() {
 
         gleamyshell.execute_in("pwd", [], output)
         |> expect.to_be_ok()
-        |> expect.to_equal(output)
+        |> expect.to_equal(output <> "\n")
       }),
     ]),
     describe("failed commands", [
@@ -135,6 +135,7 @@ pub fn cwd_tests() {
       let cwd =
         gleamyshell.execute("pwd", [])
         |> result.unwrap("")
+        |> string.trim()
 
       gleamyshell.cwd()
       |> expect.to_be_some()


### PR DESCRIPTION
# Pull Request

Issue: #4 

## Description

This PR implements the `execute_in` function. It's almost the same as the `execute` function, but it offers a `working_directory` parameter to set the directory the command is run in.

This API design choice was made to keep the amount of parameters for most standard use cases as low as possible. The `execute` function will serve most use cases just fine, and forcing users to set these parameters would make the usage cumbersome. Also, Gleam doesn't offer the ability to overload functions.