### PR TITLE
flexible version of stdlib

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -18,7 +18,7 @@ allow_run = true
 allow_sys = true
 
 [dependencies]
-gleam_stdlib = "0.37.0"
+gleam_stdlib = ">= 0.37.0"
 
 [dev-dependencies]
 startest = "0.2.4"


### PR DESCRIPTION
## Description

**gleamyshell** freezes version of `stdlib` for any project, that uses **gleamyshell**
Good practice is to have flexible versions, moreover for `stdlib`