### PR TITLE
Implement set_env function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Refactor
 
--   Finalized the API for the `execute` function.
+-   [**breaking**] Finalized the API for the `execute` function.
 
 ### Miscellaneous Tasks
 
 -   Removed Elixir as a dependency.
--   The `execute_in` function has been removed in favor of the `execute` function.
+-   [**breaking**] The `execute_in` function has been removed in favor of the `execute` function.
 
 ## 0.4.0 - 2024-05-31
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ This project employs [Conventional Commits](https://www.conventionalcommits.org/
 ## Changelog
 
 [git-cliff](https://git-cliff.org/) is used to help writing the changelog of this project. Although git-cliff does the
-heavy lifting, you should always adjust to content (e.g., changing the tense, or removing entries irrelevant for a
+heavy lifting, you should always adjust the content (e.g., changing the tense, or removing entries irrelevant for a
 changelog).
 
 You can refer to the [npm scripts](#npm-scripts) section to find out how to update and commit the changelog.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ You should use GleamyShell if
 request. GleamyShell aims to implement features that can provide a similar, or ideally the same behavior on all
 supported targets. Yours might be one of them.
 
+The main workhorse of GleamyShell is its `execute` function. The remaining functions are quality-of-life features so
+users of this library don't need to reach for further dependencies that often.
+
 ## Usage
 
 ### Getting the current username

--- a/src/gleamyshell_ffi.erl
+++ b/src/gleamyshell_ffi.erl
@@ -1,5 +1,5 @@
 -module(gleamyshell_ffi).
--export([execute/3, cwd/0, os/0, home_directory/0, env/1, which/1]).
+-export([execute/3, cwd/0, os/0, home_directory/0, env/1, set_env/2, which/1]).
 
 execute(Executable, WorkingDirectory, Args) ->
     case which(Executable) of
@@ -63,6 +63,14 @@ env(Identifier) ->
     case os:getenv(binary_to_list(Identifier)) of
         false -> none;
         Value -> {some, unicode:characters_to_binary(Value, utf8)}
+    end.
+
+set_env(Identifier, Value) ->
+    os:putenv(binary_to_list(Identifier), binary_to_list(Value)),
+
+    case env(Identifier) of
+        none -> false;
+        {some, _} -> true
     end.
 
 which(Executable) ->

--- a/src/gleamyshell_ffi.mjs
+++ b/src/gleamyshell_ffi.mjs
@@ -77,6 +77,12 @@ export function env(identifier) {
     return value == null ? new None() : new Some(value)
 }
 
+export function setEnv(identifier, value) {
+    process.env[identifier] = value
+
+    return process.env[identifier] != null
+}
+
 export function which(executable) {
     let result = {}
 

--- a/test/gleamyshell_test.gleam
+++ b/test/gleamyshell_test.gleam
@@ -22,7 +22,7 @@ pub fn execute_tests() {
           let identifier = "GLEAMYSHELL_TEST_ENV"
           let value = "Greetings!"
 
-          set_env(identifier, value)
+          gleamyshell.set_env(identifier, value)
 
           execute_test_script(
             "test/scripts/env_variable_output",
@@ -86,7 +86,7 @@ pub fn execute_tests() {
           let identifier = "GLEAMYSHELL_TEST_ENV"
           let value = "Greetings!"
 
-          set_env(identifier, value)
+          gleamyshell.set_env(identifier, value)
 
           execute_test_script(
             "env_variable_output",
@@ -178,7 +178,7 @@ pub fn env_tests() {
         let identifier = "GLEAMYSHELL_TEST_ENV"
         let value = "value"
 
-        set_env(identifier, value)
+        gleamyshell.set_env(identifier, value)
 
         gleamyshell.env(identifier)
         |> expect.to_be_some()
@@ -191,6 +191,34 @@ pub fn env_tests() {
       "returns nothing when the given environment variable does not exist",
       fn() { expect.to_be_none(gleamyshell.env("GLEAMYSHELL_TEST_ENV")) },
     ),
+  ])
+}
+
+pub fn set_env_tests() {
+  describe("gleamyshell/set_env", [
+    it("returns true when the environment variable could be set", fn() {
+      let identifier = "GLEAMYSHELL_TEST_ENV"
+      let value = "value"
+
+      gleamyshell.set_env(identifier, value)
+      |> expect.to_be_true()
+
+      gleamyshell.env(identifier)
+      |> expect.to_be_some()
+      |> expect.to_equal(value)
+
+      unset_env(identifier)
+    }),
+    it("returns false when the environment variable could not be set", fn() {
+      let identifier = "123GLEAMYSHELL_TEST_ENV"
+      let value = "value"
+
+      gleamyshell.set_env(identifier, value)
+      |> expect.to_be_false()
+
+      gleamyshell.env(identifier)
+      |> expect.to_be_none()
+    }),
   ])
 }
 
@@ -239,10 +267,6 @@ fn execute_test_script(
       ])
   }
 }
-
-@external(erlang, "gleamyshell_test_ffi", "set_env")
-@external(javascript, "./gleamyshell_test_ffi.mjs", "setEnv")
-fn set_env(identifier: String, value: String) -> Nil
 
 @external(erlang, "gleamyshell_test_ffi", "unset_env")
 @external(javascript, "./gleamyshell_test_ffi.mjs", "unsetEnv")

--- a/test/gleamyshell_test_ffi.erl
+++ b/test/gleamyshell_test_ffi.erl
@@ -1,10 +1,5 @@
 -module(gleamyshell_test_ffi).
--export([set_env/2, unset_env/1]).
-
-set_env(Identifier, Value) ->
-    os:putenv(binary_to_list(Identifier), binary_to_list(Value)),
-
-    nil.
+-export([unset_env/1]).
 
 unset_env(Identifier) ->
     os:unsetenv(binary_to_list(Identifier)),

--- a/test/gleamyshell_test_ffi.mjs
+++ b/test/gleamyshell_test_ffi.mjs
@@ -1,11 +1,5 @@
 import process from "node:process"
 
-export function setEnv(identifier, value) {
-    process.env[identifier] = value
-
-    return null
-}
-
 export function unsetEnv(identifier) {
     delete process.env[identifier]
 


### PR DESCRIPTION
# Pull Request

Issue: #37 

## Description

This PR implements the `set_env` function, which can be used to set environment variables.
