### PR TITLE
Require contributors to use specific Gleam version

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -9,8 +9,8 @@ permissions:
   pull-requests: read
 
 env:
-  CI_OTP_VERSION: "25.2"
-  CI_GLEAM_VERSION: 1.1.0
+  CI_OTP_VERSION: "27.0"
+  CI_GLEAM_VERSION: 1.2.1
   CI_REBAR3_VERSION: "3"
   CI_NODE_VERSION: 20.13.1
 
@@ -20,6 +20,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set up BEAM dependencies
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ env.CI_OTP_VERSION }}
+          gleam-version: ${{ env.CI_GLEAM_VERSION }}
+          rebar3-version: ${{ env.CI_REBAR3_VERSION }}
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
@@ -30,6 +36,8 @@ jobs:
         uses: wagoid/commitlint-github-action@v6
         with:
           configFile: commitlintrc.json
+      - name: Check formatting
+        run: npm run check
   test:
     strategy:
       matrix:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,17 @@ the formatter that comes with Gleam.
 
 You can run `npm run check` to check if everything is formatted accordingly and `npm run format` to run the formatters.
 
+To keep modules organized, you need to follow this structure:
+
+| Order |   Code Category   |
+| :---: | :---------------: |
+|   1   | public constants  |
+|   2   |   public types    |
+|   3   | public functions  |
+|   4   | private constants |
+|   5   |   private types   |
+|   6   | private functions |
+
 Apart from this, just keep your code readable. Remember, code is read more often than written. Everything else is just a
 matter of someone's personal taste, and the heavy usage of opinionated formatters just prevents such (useless)
 discussions.
@@ -50,14 +61,12 @@ You can refer to the [npm scripts](#npm-scripts) section to find out how to upda
 
 ### Setup
 
-|              Dependency               | Version  |
-| :-----------------------------------: | :------: |
-|      [Gleam](https://gleam.run/)      | \>= 1.1  |
-|        [Bun](https://bun.sh/)         | \>= 1.0  |
-|       [Deno](https://deno.com/)       | \>= 1.0  |
-|   [Node.js](https://nodejs.org/)\*    | \>= 20.0 |
-| [Docker](https://www.docker.com/)\*\* | \>= 24.0 |
-|   [act](https://nektosact.com/)\*\*   | \>= 0.2  |
+|            Dependency            | Version  |
+| :------------------------------: | :------: |
+|   [Gleam](https://gleam.run/)    |  == 1.2  |
+|      [Bun](https://bun.sh/)      | \>= 1.0  |
+|    [Deno](https://deno.com/)     | \>= 1.0  |
+| [Node.js](https://nodejs.org/)\* | \>= 20.0 |
 
 You need to run `npm ci` to set up all required npm dependencies. This ensures
 [Husky](https://typicode.github.io/husky/) configures all Git hooks and that all npm scripts are executable.
@@ -65,9 +74,6 @@ You need to run `npm ci` to set up all required npm dependencies. This ensures
 \* Although GleamyShell supports different JavaScript targets, Node.js will be required for local development to ensure
 the highest compatibility with the `package.json`. Bun and Deno are only required for executing tests to ensure
 compatibility.
-
-\*\* act and Docker are optional but recommended because act enables you to run the GitHub workflows of this project
-locally via Docker before even pushing anything to GitHub.
 
 ### npm Scripts
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![Package Version](https://img.shields.io/hexpm/v/gleamyshell)](https://hex.pm/packages/gleamyshell)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-ffaff3)](https://hexdocs.pm/gleamyshell)
+![Erlang-compatible](https://img.shields.io/badge/target-erlang-a2003e)
+![JavaScript-compatible](https://img.shields.io/badge/target-javascript-f1e05a)
+
 # GleamyShell
 
 GleamyShell is a cross-platform Gleam library for executing shell commands that supports all non-browser targets

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "gleamyshell"
-version = "1.1.0"
+version = "2.0.0"
 description = "A cross-platform Gleam library for executing shell commands."
 licences = ["MIT"]
 repository = { type = "github", user = "patrik-kuehl", repo = "gleamyshell" }

--- a/gleam.toml
+++ b/gleam.toml
@@ -3,7 +3,7 @@ version = "1.1.0"
 description = "A cross-platform Gleam library for executing shell commands."
 licences = ["MIT"]
 repository = { type = "github", user = "patrik-kuehl", repo = "gleamyshell" }
-gleam = "~> 1.0"
+gleam = ">= 1.0.0 and < 2.0.0"
 
 [documentation]
 pages = [


### PR DESCRIPTION
# Pull Request

Issue: #50 

## Description

This PR updates the contribution guidelines to require contributors to use a specific Gleam version. It also ensures the. CI/CD pipeline uses the same Gleam version.

Due to incoming breaking API changes to make the API of GleamyShell more Gleam idiomatic, the version has been bumped to 2.0.0. Functions that currently return an `Option` will be refactored to return a `Result`.
