### PR TITLE
Refactor cwd to return a result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+-   **(breaking)** Made `gleamyshell/cwd` return a `Result` instead of an `Option`.
+
 ## [1.1.0] - 2024-06-06
 
 ### Added

--- a/src/gleamyshell.gleam
+++ b/src/gleamyshell.gleam
@@ -85,20 +85,18 @@ pub fn execute(
 
 /// Returns the current working directory.
 /// 
-/// This function returns an `Option` because it can fail on Unix-like systems in rare circumstances.
-/// 
 /// ## Example
 /// 
 /// ```gleam
 /// case gleamyshell.cwd() {
-///   Some(working_directory) ->
+///   Ok(working_directory) ->
 ///     io.println("Current working directory: " <> working_directory)
-///   None -> io.println("Couldn't detect the current working directory.")
+///   Error(_) -> io.println("Couldn't detect the current working directory.")
 /// }
 /// ```
 @external(erlang, "gleamyshell_ffi", "cwd")
 @external(javascript, "./gleamyshell_ffi.mjs", "cwd")
-pub fn cwd() -> Option(String)
+pub fn cwd() -> Result(String, Nil)
 
 /// Returns information about the host's operating system.
 /// 

--- a/src/gleamyshell_ffi.erl
+++ b/src/gleamyshell_ffi.erl
@@ -35,11 +35,11 @@ cwd() ->
         {ok, Cwd} = file:get_cwd(),
 
         case os() of
-            windows -> {some, sanitize_path_on_windows(Cwd)};
-            _ -> {some, unicode:characters_to_binary(Cwd, utf8)}
+            windows -> {ok, sanitize_path_on_windows(Cwd)};
+            _ -> {ok, unicode:characters_to_binary(Cwd, utf8)}
         end
     catch
-        _ -> none
+        _ -> {error, nil}
     end.
 
 os() ->

--- a/src/gleamyshell_ffi.mjs
+++ b/src/gleamyshell_ffi.mjs
@@ -34,9 +34,9 @@ export function execute(executable, workingDirectory, args) {
 
 export function cwd() {
     try {
-        return new Some(process.cwd())
+        return new Ok(process.cwd())
     } catch {
-        return new None()
+        return new Error(null)
     }
 }
 

--- a/test/gleamyshell_test.gleam
+++ b/test/gleamyshell_test.gleam
@@ -169,7 +169,7 @@ pub fn cwd_tests() {
         |> string.trim()
 
       gleamyshell.cwd()
-      |> expect.to_be_some()
+      |> expect.to_be_ok()
       |> expect.to_equal(cwd)
     }),
   ])


### PR DESCRIPTION
# Pull Request

Issue: #53 

## Description

This PR refactors `gleamyshell/cwd` to return a `Result` instead of an `Option`.
