### PR TITLE
Refactor home_directory to return a result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
 ### Changed
 
+-   **(breaking)** Made `gleamyshell/home_directory` return a `Result` instead of an `Option`.
 -   **(breaking)** Made `gleamyshell/cwd` return a `Result` instead of an `Option`.
 
 ## [1.1.0] - 2024-06-06

--- a/src/gleamyshell.gleam
+++ b/src/gleamyshell.gleam
@@ -120,14 +120,14 @@ pub fn os() -> OsFamily
 /// 
 /// ```gleam
 /// case gleamyshell.home_directory() {
-///   Some(home_directory) -> io.println("Home directory: " <> home_directory)
-///   None ->
+///   Ok(home_directory) -> io.println("Home directory: " <> home_directory)
+///   Error(_) ->
 ///     io.println("Couldn't detect the home directory of the current user.")
 /// }
 /// ```
 @external(erlang, "gleamyshell_ffi", "home_directory")
 @external(javascript, "./gleamyshell_ffi.mjs", "homeDirectory")
-pub fn home_directory() -> Option(String)
+pub fn home_directory() -> Result(String, Nil)
 
 /// Returns the value of the given environment variable if it is set.
 /// 

--- a/src/gleamyshell_ffi.erl
+++ b/src/gleamyshell_ffi.erl
@@ -55,8 +55,8 @@ os() ->
 
 home_directory() ->
     case init:get_argument(home) of
-        {ok, [[Dir] | _]} -> {some, unicode:characters_to_binary(Dir, utf8)};
-        _ -> none
+        {ok, [[Dir] | _]} -> {ok, unicode:characters_to_binary(Dir, utf8)};
+        _ -> {error, nil}
     end.
 
 env(Identifier) ->

--- a/src/gleamyshell_ffi.mjs
+++ b/src/gleamyshell_ffi.mjs
@@ -63,9 +63,9 @@ export function os() {
 
 export function homeDirectory() {
     try {
-        return new Some(operating_system.homedir())
+        return new Ok(operating_system.homedir())
     } catch {
-        return new None()
+        return new Error(null)
     }
 }
 

--- a/test/gleamyshell_test.gleam
+++ b/test/gleamyshell_test.gleam
@@ -188,7 +188,7 @@ pub fn home_directory_tests() {
         |> string.trim()
 
       gleamyshell.home_directory()
-      |> expect.to_be_some()
+      |> expect.to_be_ok()
       |> expect.to_equal(home_directory)
     }),
   ])


### PR DESCRIPTION
# Pull Request

Issue: #54 

## Description

This PR refactors `gleamyshell/home_directory` to return a `Result` instead of an `Option`.
