### PR TITLE
Make set_env return a result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+-   **(breaking)** Made `gleamyshell/set_env` return a `Result` instead of a `Bool`.
 -   **(breaking)** Made `gleamyshell/env` return a `Result` instead of an `Option`.
 -   **(breaking)** Made `gleamyshell/home_directory` return a `Result` instead of an `Option`.
 -   **(breaking)** Made `gleamyshell/cwd` return a `Result` instead of an `Option`.

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 ![Erlang-compatible](https://img.shields.io/badge/target-erlang-a2003e)
 ![JavaScript-compatible](https://img.shields.io/badge/target-javascript-f1e05a)
 
-# GleamyShell
+# GleamyShell 🐚
 
 GleamyShell is a cross-platform Gleam library for executing shell commands that supports all non-browser targets
 (Erlang, Bun, Deno, and Node.js).
 
-## When to use GleamyShell?
+## When to use GleamyShell? 🐚
 
 GleamyShell provides the ability to execute shell commands on multiple targets. While this might sound amazing,
 supporting targets with fundamentally different concurrency models and APIs shrinks the common ground significantly.
@@ -29,7 +29,7 @@ supported targets. Yours might be one of them.
 The main workhorse of GleamyShell is its `execute` function. The remaining functions are quality-of-life features so
 users of this library don't need to reach for further dependencies that often.
 
-## Usage
+## Usage 🐚
 
 ### Getting the current username
 
@@ -69,15 +69,15 @@ case gleamyshell.os() {
 }
 ```
 
-## Changelog
+## Changelog 🐚
 
 Take a look at the [changelog](https://github.com/patrik-kuehl/gleamyshell/blob/main/CHANGELOG.md) to get an overview of
 each release and its changes.
 
-## Contribution Guidelines
+## Contribution Guidelines 🐚
 
 More information can be found [here](https://github.com/patrik-kuehl/gleamyshell/blob/main/CONTRIBUTING.md).
 
-## License
+## License 🐚
 
 GleamyShell is licensed under the [MIT license](https://github.com/patrik-kuehl/gleamyshell/blob/main/LICENSE.md).

--- a/src/gleamyshell_ffi.erl
+++ b/src/gleamyshell_ffi.erl
@@ -69,8 +69,8 @@ set_env(Identifier, Value) ->
     os:putenv(binary_to_list(Identifier), binary_to_list(Value)),
 
     case env(Identifier) of
-        {error, _} -> false;
-        {ok, _} -> true
+        {error, _} -> {error, could_not_be_set};
+        Result -> Result
     end.
 
 unset_env(Identifier) ->

--- a/src/gleamyshell_ffi.mjs
+++ b/src/gleamyshell_ffi.mjs
@@ -22,6 +22,7 @@ import {
     Eacces,
     Enoent,
     OtherAbortReason,
+    CouldNotBeSet,
 } from "./gleamyshell.mjs"
 
 export function execute(executable, workingDirectory, args) {
@@ -78,7 +79,7 @@ export function env(identifier) {
 export function setEnv(identifier, value) {
     process.env[identifier] = value
 
-    return process.env[identifier] != null
+    return process.env[identifier] == null ? new Error(new CouldNotBeSet()) : new Ok(process.env[identifier])
 }
 
 export function unsetEnv(identifier) {

--- a/test/gleamyshell_test.gleam
+++ b/test/gleamyshell_test.gleam
@@ -1,11 +1,9 @@
 import gleam/string
-import gleamyshell.{type CommandError, Abort, Enoent, Failure, Unix, Windows}
+import gleamyshell.{
+  type CommandError, Abort, Enoent, Failure, InvalidIdentifier, Unix, Windows,
+}
 import startest.{describe, it}
 import startest/expect
-
-const test_scripts_directory = "./test/scripts/"
-
-const test_environment_variable_identifier = "GLEAMYSHELL_TEST_ENV"
 
 pub fn main() {
   startest.run(startest.default_config())
@@ -30,6 +28,7 @@ pub fn execute_tests() {
           let value = "Greetings!"
 
           gleamyshell.set_env(test_environment_variable_identifier, value)
+          |> expect.to_be_ok()
 
           execute_test_script(
             test_scripts_directory <> "env_variable_output",
@@ -101,6 +100,7 @@ pub fn execute_tests() {
           let value = "Greetings!"
 
           gleamyshell.set_env(test_environment_variable_identifier, value)
+          |> expect.to_be_ok()
 
           execute_test_script(
             "env_variable_output",
@@ -202,6 +202,7 @@ pub fn env_tests() {
         let value = "value"
 
         gleamyshell.set_env(test_environment_variable_identifier, value)
+        |> expect.to_be_ok()
 
         gleamyshell.env(test_environment_variable_identifier)
         |> expect.to_be_ok()
@@ -225,7 +226,7 @@ pub fn set_env_tests() {
       let value = "value"
 
       gleamyshell.set_env(test_environment_variable_identifier, value)
-      |> expect.to_be_true()
+      |> expect.to_be_ok()
 
       gleamyshell.env(test_environment_variable_identifier)
       |> expect.to_be_ok()
@@ -238,7 +239,8 @@ pub fn set_env_tests() {
       let value = "value"
 
       gleamyshell.set_env(identifier, value)
-      |> expect.to_be_false()
+      |> expect.to_be_error()
+      |> expect.to_equal(InvalidIdentifier)
 
       gleamyshell.env(identifier)
       |> expect.to_be_error()
@@ -252,7 +254,7 @@ pub fn unset_env_tests() {
   describe("gleamyshell/unset_env", [
     it("returns true when the environment variable could be unset", fn() {
       gleamyshell.set_env(test_environment_variable_identifier, "value")
-      |> expect.to_be_true()
+      |> expect.to_be_ok()
 
       gleamyshell.unset_env(test_environment_variable_identifier)
       |> expect.to_be_true()
@@ -292,6 +294,10 @@ pub fn which_tests() {
     }),
   ])
 }
+
+const test_scripts_directory = "./test/scripts/"
+
+const test_environment_variable_identifier = "GLEAMYSHELL_TEST_ENV"
 
 fn execute_test_script(
   file_name: String,


### PR DESCRIPTION
# Pull Request

Issue: #57 

## Description

This PR refactors `gleamyshell/set_env` to return a `Result` instead of a `Bool`.
