### PR TITLE
Remove set_env and unset_env functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
--   **(breaking)** Made `gleamyshell/set_env` return a `Result` instead of a `Bool`.
 -   **(breaking)** Made `gleamyshell/env` return a `Result` instead of an `Option`.
 -   **(breaking)** Made `gleamyshell/home_directory` return a `Result` instead of an `Option`.
 -   **(breaking)** Made `gleamyshell/cwd` return a `Result` instead of an `Option`.
+
+### Removed
+
+-   **(breaking)** Removed `gleamyshell/set_env` due to limitations of the APIs of Erlang and Node.js.
+-   **(breaking)** Removed `gleamyshell/unset_env`.
 
 ## [1.1.0] - 2024-06-06
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ users of this library don't need to reach for further dependencies that often.
 
 ## Usage 🐚
 
-### Getting the current username
+### Getting the current username 🐚
 
 ```gleam
 case gleamyshell.execute("whoami", in: ".", args: []) {
@@ -48,7 +48,7 @@ case gleamyshell.execute("whoami", in: ".", args: []) {
 }
 ```
 
-### Getting the current working directory
+### Getting the current working directory 🐚
 
 ```gleam
 case gleamyshell.cwd() {
@@ -59,7 +59,7 @@ case gleamyshell.cwd() {
 }
 ```
 
-### Choosing what to do depending on the operating system
+### Choosing what to do depending on the operating system 🐚
 
 ```gleam
 case gleamyshell.os() {

--- a/src/gleamyshell_ffi.erl
+++ b/src/gleamyshell_ffi.erl
@@ -1,5 +1,5 @@
 -module(gleamyshell_ffi).
--export([execute/3, cwd/0, os/0, home_directory/0, env/1, set_env/2, unset_env/1, which/1]).
+-export([execute/3, cwd/0, os/0, home_directory/0, env/1, which/1]).
 
 execute(Executable, WorkingDirectory, Args) ->
     case which(Executable) of
@@ -63,22 +63,6 @@ env(Identifier) ->
     case os:getenv(binary_to_list(Identifier)) of
         false -> {error, nil};
         Value -> {ok, unicode:characters_to_binary(Value, utf8)}
-    end.
-
-set_env(Identifier, Value) ->
-    os:putenv(binary_to_list(Identifier), binary_to_list(Value)),
-
-    case env(Identifier) of
-        {error, _} -> {error, could_not_be_set};
-        Result -> Result
-    end.
-
-unset_env(Identifier) ->
-    os:unsetenv(binary_to_list(Identifier)),
-
-    case env(Identifier) of
-        {error, _} -> true;
-        {ok, _} -> false
     end.
 
 which(Executable) ->

--- a/src/gleamyshell_ffi.mjs
+++ b/src/gleamyshell_ffi.mjs
@@ -22,7 +22,6 @@ import {
     Eacces,
     Enoent,
     OtherAbortReason,
-    CouldNotBeSet,
 } from "./gleamyshell.mjs"
 
 export function execute(executable, workingDirectory, args) {
@@ -74,18 +73,6 @@ export function env(identifier) {
     const value = process.env[identifier]
 
     return value == null ? new Error(null) : new Ok(value)
-}
-
-export function setEnv(identifier, value) {
-    process.env[identifier] = value
-
-    return process.env[identifier] == null ? new Error(new CouldNotBeSet()) : new Ok(process.env[identifier])
-}
-
-export function unsetEnv(identifier) {
-    delete process.env[identifier]
-
-    return process.env[identifier] == null
 }
 
 export function which(executable) {

--- a/test/scripts/env_variable_output.ps1
+++ b/test/scripts/env_variable_output.ps1
@@ -1,1 +1,0 @@
-echo $env:GLEAMYSHELL_TEST_ENV

--- a/test/scripts/env_variable_output.sh
+++ b/test/scripts/env_variable_output.sh
@@ -1,1 +1,0 @@
-echo $GLEAMYSHELL_TEST_ENV

--- a/test/scripts/path_env_output.ps1
+++ b/test/scripts/path_env_output.ps1
@@ -1,0 +1,1 @@
+echo $env:PATH

--- a/test/scripts/path_env_output.sh
+++ b/test/scripts/path_env_output.sh
@@ -1,0 +1,1 @@
+echo $PATH


### PR DESCRIPTION
# Pull Request

Issue: #58 

## Description

This PR removes the `set_env` and `unset_env` functions. `set_env` suffers from limitations of the APIs of Erlang and Node.js. The main reason is the lack of support for nested environment variables. Due to this, the public interface of GleamyShell will be reduced in the next major version.
