### PR TITLE
Treat non-zero exit codes not as errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+-   **(breaking)** `gleamyshell/execute` doesn't treat non-zero exit codes as errors any longer.
 -   **(breaking)** Made `gleamyshell/which` return a `Result` instead of an `Option`.
 -   **(breaking)** Made `gleamyshell/env` return a `Result` instead of an `Option`.
 -   **(breaking)** Made `gleamyshell/home_directory` return a `Result` instead of an `Option`.

--- a/README.md
+++ b/README.md
@@ -31,24 +31,24 @@ users of this library don't need to reach for further dependencies that often.
 
 ## Usage 🐚
 
-### Getting the current username 🐚
+### Getting the Current Username 🐚
 
 ```gleam
 case gleamyshell.execute("whoami", in: ".", args: []) {
-  Ok(username) ->
+  Ok(CommandOutput(0, username)) ->
     io.println("Hello there, " <> string.trim(username) <> "!")
-  Error(Failure(output, exit_code)) ->
+  Ok(CommandOutput(exit_code, output)) ->
     io.println(
       "Whoops!\nError ("
       <> int.to_string(exit_code)
       <> "): "
       <> string.trim(output),
     )
-  Error(Abort(_)) -> io.println("Something went terribly wrong.")
+  Error(reason) -> io.println("Fatal: " <> reason)
 }
 ```
 
-### Getting the current working directory 🐚
+### Getting the Current Working Directory 🐚
 
 ```gleam
 case gleamyshell.cwd() {
@@ -59,7 +59,7 @@ case gleamyshell.cwd() {
 }
 ```
 
-### Choosing what to do depending on the operating system 🐚
+### Do OS-specific Stuff 🐚
 
 ```gleam
 case gleamyshell.os() {

--- a/gleam.toml
+++ b/gleam.toml
@@ -21,4 +21,4 @@ allow_sys = true
 gleam_stdlib = ">= 0.37.0 and < 2.0.0"
 
 [dev-dependencies]
-startest = ">= 0.2.4 and < 2.0.0"
+gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,27 +2,10 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
-  { name = "bigben", version = "1.0.0", build_tools = ["gleam"], requirements = ["birl", "gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "bigben", source = "hex", outer_checksum = "8E5A98FA6E981EEEF016C40F1CDFADA095927CAF6CAAA0C7E295EED02FC95947" },
-  { name = "birl", version = "1.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "ranger"], otp_app = "birl", source = "hex", outer_checksum = "B1FA529E7BE3FF12CADF32814AB8EC7294E74CEDEE8CC734505707B929A98985" },
-  { name = "exception", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "F5580D584F16A20B7FCDCABF9E9BE9A2C1F6AC4F9176FA6DD0B63E3B20D450AA" },
-  { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
-  { name = "gleam_community_ansi", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "FE79E08BF97009729259B6357EC058315B6FBB916FAD1C2FF9355115FEB0D3A4" },
-  { name = "gleam_community_colour", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "795964217EBEDB3DA656F5EB8F67D7AD22872EB95182042D3E7AFEF32D3FD2FE" },
-  { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
-  { name = "gleam_javascript", version = "0.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_javascript", source = "hex", outer_checksum = "14D5B7E1A70681E0776BF0A0357F575B822167960C844D3D3FA114D3A75F05A8" },
-  { name = "gleam_json", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "thoas"], otp_app = "gleam_json", source = "hex", outer_checksum = "9063D14D25406326C0255BDA0021541E797D8A7A12573D849462CAFED459F6EB" },
-  { name = "gleam_otp", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "0B04FE915ACECE539B317F9652CAADBBC0F000184D586AAAF2D94C100945D72B" },
   { name = "gleam_stdlib", version = "0.38.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "663CF11861179AF415A625307447775C09404E752FF99A24E2057C835319F1BE" },
-  { name = "glint", version = "1.0.0-rc2", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "FD5C47CE237CA67121F3946ADE7C630750BB67F5E8A4717D2DF5B5EE758CCFDB" },
-  { name = "ranger", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "ranger", source = "hex", outer_checksum = "1566C272B1D141B3BBA38B25CB761EF56E312E79EC0E2DFD4D3C19FB0CC1F98C" },
-  { name = "simplifile", version = "1.7.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "1D5DFA3A2F9319EC85825F6ED88B8E449F381B0D55A62F5E61424E748E7DDEB0" },
-  { name = "snag", version = "0.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "54D32E16E33655346AA3E66CBA7E191DE0A8793D2C05284E3EFB90AD2CE92BCC" },
-  { name = "startest", version = "0.2.4", build_tools = ["gleam"], requirements = ["argv", "bigben", "birl", "exception", "gleam_community_ansi", "gleam_erlang", "gleam_javascript", "gleam_stdlib", "glint", "simplifile", "tom"], otp_app = "startest", source = "hex", outer_checksum = "1734A986F2920DC69BF4639C10E5BEFEBA5A968D3F035C8A473A63D1F84E65BD" },
-  { name = "thoas", version = "1.2.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "E38697EDFFD6E91BD12CEA41B155115282630075C2A727E7A6B2947F5408B86A" },
-  { name = "tom", version = "0.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "tom", source = "hex", outer_checksum = "0831C73E45405A2153091226BF98FB485ED16376988602CC01A5FD086B82D577" },
+  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
 ]
 
 [requirements]
 gleam_stdlib = { version = ">= 0.37.0 and < 2.0.0" }
-startest = { version = ">= 0.2.4 and < 2.0.0" }
+gleeunit = { version = ">= 1.0.0 and < 2.0.0" }

--- a/src/gleamyshell.gleam
+++ b/src/gleamyshell.gleam
@@ -1,33 +1,11 @@
-/// Represents information about why a command execution failed.
-pub type CommandError {
-  /// The command could be executed but returned a non-zero exit code.
-  Failure(output: String, exit_code: Int)
-  /// The command could not be executed completely and was aborted. You usually
-  /// don't want to pattern match the specific reason and when targeting Bun,
-  /// you won't receive any reason besides `Enoent` due to Bun's limitations here.
-  Abort(reason: AbortReason)
-}
-
-/// Represents the reason why the execution of a command was aborted.
-///
-/// Most of these reasons are common POSIX errors.
-pub type AbortReason {
-  /// Not enough memory.
-  Enomem
-  /// Resource temporarily unavailable.
-  Eagain
-  /// Too long file name.
-  Enametoolong
-  /// Too many open files.
-  Emfile
-  /// File table overflow.
-  Enfile
-  /// Insufficient permissions.
-  Eacces
-  /// No such file or directory.
-  Enoent
-  /// An error not represented by the other options.
-  OtherAbortReason(String)
+/// Represents information about the exit code and output of the
+/// executed command.
+/// 
+/// `output` equals the output stream (stdout) when the command
+/// exited with an exit code of one, otherwise it equals the
+/// error stream (stderr).
+pub type CommandOutput {
+  CommandOutput(exit_code: Int, output: String)
 }
 
 /// Represents families of operating systems.
@@ -63,16 +41,16 @@ pub type Os {
 /// 
 /// ```gleam
 /// case gleamyshell.execute("whoami", in: ".", args: []) {
-///   Ok(username) ->
+///   Ok(CommandOutput(0, username)) ->
 ///     io.println("Hello there, " <> string.trim(username) <> "!")
-///   Error(Failure(output, exit_code)) ->
+///   Ok(CommandOutput(exit_code, output)) ->
 ///     io.println(
 ///       "Whoops!\nError ("
 ///       <> int.to_string(exit_code)
 ///       <> "): "
 ///       <> string.trim(output),
 ///     )
-///   Error(Abort(_)) -> io.println("Something went terribly wrong.")
+///   Error(reason) -> io.println("Fatal: " <> reason)
 /// }
 /// ```
 @external(erlang, "gleamyshell_ffi", "execute")
@@ -81,7 +59,7 @@ pub fn execute(
   executable: String,
   in working_directory: String,
   args args: List(String),
-) -> Result(String, CommandError)
+) -> Result(CommandOutput, String)
 
 /// Returns the current working directory.
 /// 

--- a/src/gleamyshell_ffi.erl
+++ b/src/gleamyshell_ffi.erl
@@ -4,29 +4,12 @@
 execute(Executable, WorkingDirectory, Args) ->
     case which(Executable) of
         {error, _} ->
-            {error, {abort, enoent}};
+            {error, atom_to_binary(enoent, utf8)};
         {ok, ExecutablePath} ->
             try
                 do_execute(ExecutablePath, WorkingDirectory, Args)
             catch
-                _:Reason ->
-                    case Reason of
-                        enomem ->
-                            {error, {abort, enomem}};
-                        eagain ->
-                            {error, {abort, eagain}};
-                        enametoolong ->
-                            {error, {abort, enametoolong}};
-                        emfile ->
-                            {error, {abort, emfile}};
-                        enfile ->
-                            {error, {abort, enfile}};
-                        eacces ->
-                            {error, {abort, eacces}};
-                        OtherReason ->
-                            {error,
-                                {abort, {other_abort_reason, atom_to_binary(OtherReason, utf8)}}}
-                    end
+                _:Reason -> {error, atom_to_binary(Reason, utf8)}
             end
     end.
 
@@ -87,10 +70,8 @@ do_execute(ExecutablePath, WorkingDirectory, Args) ->
     ),
 
     case port_result(Port, []) of
-        {Output, 0} ->
-            {ok, unicode:characters_to_binary(Output, utf8)};
         {Output, ExitCode} ->
-            {error, {failure, unicode:characters_to_binary(Output, utf8), ExitCode}}
+            {ok, {command_output, ExitCode, unicode:characters_to_binary(Output, utf8)}}
     end.
 
 port_result(Port, IntermediateOutput) ->

--- a/src/gleamyshell_ffi.mjs
+++ b/src/gleamyshell_ffi.mjs
@@ -59,11 +59,13 @@ export function which(executable) {
     const windowsArgs = ["powershell", `(gcm ${executable}).Path`]
     const unixArgs = ["which", executable]
 
-    let result = isEqual(os(), new Windows())
+    const result = isEqual(os(), new Windows())
         ? spawnSync(windowsArgs[0], [windowsArgs[1]], ".")
         : spawnSync(unixArgs[0], [unixArgs[1]], ".")
 
-    return result[0].exit_code === 0 ? new Ok(result[0].output.trim()) : new Error(null)
+    const output = result[0].output.trim()
+
+    return result[0].exit_code === 0 && output !== "" ? new Ok(output) : new Error(null)
 }
 
 function spawnSync(executable, args, workingDirectory) {

--- a/test/gleamyshell_test.gleam
+++ b/test/gleamyshell_test.gleam
@@ -1,192 +1,150 @@
 import gleam/string
 import gleamyshell.{type CommandOutput, CommandOutput, Unix, Windows}
-import startest.{describe, it}
-import startest/expect
+import gleeunit
+import gleeunit/should
 
 pub fn main() {
-  startest.run(startest.default_config())
+  gleeunit.main()
 }
 
-pub fn execute_tests() {
-  describe("gleamyshell/execute", [
-    describe("in working directory \".\"", [
-      it("returns expected output when command succeeded", fn() {
-        let assert CommandOutput(0, output) =
-          execute_test_script(
-            test_scripts_directory <> "greeting",
-            in: ".",
-            args: [],
-          )
-          |> expect.to_be_ok()
+pub fn execute_test() {
+  let assert CommandOutput(0, output) =
+    execute_test_script(test_scripts_directory <> "greeting", in: ".", args: [])
+    |> should.be_ok()
 
-        output
-        |> string.trim()
-        |> expect.to_equal("Hello there!")
-      }),
-      it("returns expected output identical to the passed argument", fn() {
-        let value = "test"
+  output
+  |> string.trim()
+  |> should.equal("Hello there!")
+  |> because("it equals the stdout of the command")
 
-        let assert CommandOutput(0, output) =
-          execute_test_script(
-            test_scripts_directory <> "argument",
-            in: ".",
-            args: [value],
-          )
-          |> expect.to_be_ok()
+  let value = "test"
 
-        output
-        |> string.trim()
-        |> expect.to_equal(value)
-      }),
-      it("returns ENOENT error", fn() {
-        gleamyshell.execute("_whoami_", in: ".", args: [])
-        |> expect.to_be_error()
-        |> expect.to_equal("enoent")
-      }),
-      it("returns expected output when command failed", fn() {
-        let assert CommandOutput(1, output) =
-          execute_test_script(
-            test_scripts_directory <> "failed_command",
-            in: ".",
-            args: [],
-          )
-          |> expect.to_be_ok()
+  let assert CommandOutput(0, output) =
+    execute_test_script(test_scripts_directory <> "argument", in: ".", args: [
+      value,
+    ])
+    |> should.be_ok()
 
-        output
-        |> string.trim()
-        |> expect.to_equal("Nothing to worry about.")
-      }),
-    ]),
-    describe("in working directory \"" <> test_scripts_directory <> "\"", [
-      it("returns expected output when command succeeded", fn() {
-        let assert CommandOutput(0, output) =
-          execute_test_script("greeting", in: test_scripts_directory, args: [])
-          |> expect.to_be_ok()
+  output
+  |> string.trim()
+  |> should.equal(value)
+  |> because("the passed argument is identical to the stdout of the command")
 
-        output
-        |> string.trim()
-        |> expect.to_equal("Hello there!")
-      }),
-      it("returns expected output identical to the passed argument", fn() {
-        let value = "test"
+  gleamyshell.execute("_whoami_", in: ".", args: [])
+  |> should.be_error()
+  |> should.equal("enoent")
+  |> because("the executable could not be found")
 
-        let assert CommandOutput(0, output) =
-          execute_test_script("argument", in: test_scripts_directory, args: [
-            value,
-          ])
-          |> expect.to_be_ok()
+  let assert CommandOutput(1, output) =
+    execute_test_script(
+      test_scripts_directory <> "failed_command",
+      in: ".",
+      args: [],
+    )
+    |> should.be_ok()
 
-        output
-        |> string.trim()
-        |> expect.to_equal(value)
-      }),
-      it("returns ENOENT error", fn() {
-        gleamyshell.execute("_whoami_", in: test_scripts_directory, args: [])
-        |> expect.to_be_error()
-        |> expect.to_equal("enoent")
-      }),
-      it("returns expected output when command failed", fn() {
-        let assert CommandOutput(1, output) =
-          execute_test_script(
-            "failed_command",
-            in: test_scripts_directory,
-            args: [],
-          )
-          |> expect.to_be_ok()
+  output
+  |> string.trim()
+  |> should.equal("Nothing to worry about.")
+  |> because("it equals the stderr of the command")
 
-        output
-        |> string.trim()
-        |> expect.to_equal("Nothing to worry about.")
-      }),
-    ]),
-  ])
+  let assert CommandOutput(0, output) =
+    execute_test_script("greeting", in: test_scripts_directory, args: [])
+    |> should.be_ok()
+    |> because("it equals the stdout of the command")
+
+  output
+  |> string.trim()
+  |> should.equal("Hello there!")
+
+  let value = "test"
+
+  let assert CommandOutput(0, output) =
+    execute_test_script("argument", in: test_scripts_directory, args: [value])
+    |> should.be_ok()
+
+  output
+  |> string.trim()
+  |> should.equal(value)
+  |> because("the passed argument is identical to the stdout of the command")
+
+  gleamyshell.execute("_whoami_", in: test_scripts_directory, args: [])
+  |> should.be_error()
+  |> should.equal("enoent")
+  |> because("the executable could not be found")
+
+  let assert CommandOutput(1, output) =
+    execute_test_script("failed_command", in: test_scripts_directory, args: [])
+    |> should.be_ok()
+
+  output
+  |> string.trim()
+  |> should.equal("Nothing to worry about.")
+  |> because("it equals the stderr of the command")
 }
 
-pub fn cwd_tests() {
-  describe("gleamyshell/cwd", [
-    it("returns the current working directory", fn() {
-      let CommandOutput(_, cwd) =
-        execute_test_script(test_scripts_directory <> "pwd", in: ".", args: [])
-        |> expect.to_be_ok()
+pub fn cwd_test() {
+  let CommandOutput(_, cwd) =
+    execute_test_script(test_scripts_directory <> "pwd", in: ".", args: [])
+    |> should.be_ok()
 
-      gleamyshell.cwd()
-      |> expect.to_be_ok()
-      |> expect.to_equal(cwd |> string.trim())
-    }),
-  ])
+  gleamyshell.cwd()
+  |> should.be_ok()
+  |> should.equal(cwd |> string.trim())
 }
 
-pub fn home_directory_tests() {
-  describe("gleamyshell/home_directory", [
-    it("returns the home directory of the current user", fn() {
-      let CommandOutput(_, home_directory) =
-        execute_test_script(
-          test_scripts_directory <> "home_directory",
-          in: ".",
-          args: [],
-        )
-        |> expect.to_be_ok()
+pub fn home_directory_test() {
+  let CommandOutput(_, home_directory) =
+    execute_test_script(
+      test_scripts_directory <> "home_directory",
+      in: ".",
+      args: [],
+    )
+    |> should.be_ok()
 
-      gleamyshell.home_directory()
-      |> expect.to_be_ok()
-      |> expect.to_equal(home_directory |> string.trim())
-    }),
-  ])
+  gleamyshell.home_directory()
+  |> should.be_ok()
+  |> should.equal(home_directory |> string.trim())
 }
 
-pub fn env_tests() {
-  describe("gleamyshell/env", [
-    it(
-      "returns the value of the given environment variable when it exists",
-      fn() {
-        let CommandOutput(_, path) =
-          execute_test_script(
-            test_scripts_directory <> "path_env_output",
-            in: ".",
-            args: [],
-          )
-          |> expect.to_be_ok()
+pub fn env_test() {
+  let CommandOutput(_, path) =
+    execute_test_script(
+      test_scripts_directory <> "path_env_output",
+      in: ".",
+      args: [],
+    )
+    |> should.be_ok()
 
-        gleamyshell.env("PATH")
-        |> expect.to_be_ok()
-        |> expect.to_equal(path |> string.trim())
-      },
-    ),
-    it(
-      "returns an error when the given environment variable does not exist",
-      fn() { expect.to_be_error(gleamyshell.env("i_dont_exist")) },
-    ),
-  ])
+  gleamyshell.env("PATH")
+  |> should.be_ok()
+  |> should.equal(path |> string.trim())
+  |> because("the environment variable exists")
+
+  gleamyshell.env("i_dont_exist")
+  |> should.be_error()
+  |> because("the environment variable does not exist")
 }
 
-pub fn which_tests() {
-  describe("gleamyshell/which", [
-    it("returns the path of the given executable when it could be found", fn() {
-      let CommandOutput(_, executable_path) =
-        execute_test_script(
-          test_scripts_directory <> "which",
-          in: ".",
-          args: [],
-        )
-        |> expect.to_be_ok()
+pub fn which_test() {
+  let CommandOutput(_, executable_path) =
+    execute_test_script(test_scripts_directory <> "which", in: ".", args: [])
+    |> should.be_ok()
 
-      case gleamyshell.os() {
-        Windows ->
-          gleamyshell.which("cmd")
-          |> expect.to_be_ok()
-          |> expect.to_equal(executable_path |> string.trim())
-        Unix(_) ->
-          gleamyshell.which("sh")
-          |> expect.to_be_ok()
-          |> expect.to_equal(executable_path |> string.trim())
-      }
+  case gleamyshell.os() {
+    Windows ->
+      gleamyshell.which("cmd")
+      |> should.be_ok()
+    Unix(_) ->
+      gleamyshell.which("sh")
+      |> should.be_ok()
+  }
+  |> should.equal(executable_path |> string.trim())
+  |> because("the executable could be found")
 
-      Nil
-    }),
-    it("returns an error when the given executable could not be found", fn() {
-      expect.to_be_error(gleamyshell.which("_whoami_"))
-    }),
-  ])
+  gleamyshell.which("_whoami_")
+  |> should.be_error()
+  |> because("the executable could not be found")
 }
 
 const test_scripts_directory = "./test/scripts/"
@@ -208,4 +166,8 @@ fn execute_test_script(
         ..args
       ])
   }
+}
+
+fn because(assertion_result: a, _description: String) -> a {
+  assertion_result
 }


### PR DESCRIPTION
# Pull Request

Issue: #60 

## Description

This PR adjusts `gleamyshell/execute` to not treat non-zero exit codes as errors. In case the command could exit, whatever exit code it may have returned, is a success for GleamyShell. If the command fails to run it returns an error.
