### PR TITLE
Remove outdated doc comment sentence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2024-07-14
+
+### Removed
+
+-   Removed an outdated sentence in the documentation comment of `gleamyshell/home_directory`.
+
 ## [2.0.0] - 2024-07-12
 
 ### Changed
@@ -82,7 +88,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 -   Added `gleamyshell/execute` to run a command.
 -   Defined the `gleamyshell/CommandError` and `gleamyshell/AbortReason` types.
 
-[unreleased]: https://github.com/patrik-kuehl/gleamyshell/compare/v2.0.0...HEAD
+[unreleased]: https://github.com/patrik-kuehl/gleamyshell/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/patrik-kuehl/gleamyshell/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/patrik-kuehl/gleamyshell/compare/v1.1.0...v2.0.0
 [1.1.0]: https://github.com/patrik-kuehl/gleamyshell/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/patrik-kuehl/gleamyshell/compare/v0.5.0...v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,11 +27,11 @@ To keep modules organized, you need to follow this structure:
 
 | Order |   Code Category   |
 | :---: | :---------------: |
-|   1   | public constants  |
-|   2   |   public types    |
+|   1   |   public types    |
+|   2   | public constants  |
 |   3   | public functions  |
-|   4   | private constants |
-|   5   |   private types   |
+|   4   |   private types   |
+|   5   | private constants |
 |   6   | private functions |
 
 Apart from this, just keep your code readable. Remember, code is read more often than written. Everything else is just a

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "gleamyshell"
-version = "2.0.0"
+version = "2.0.1"
 description = "A cross-platform Gleam library for executing shell commands."
 licences = ["MIT"]
 repository = { type = "github", user = "patrik-kuehl", repo = "gleamyshell" }

--- a/src/gleamyshell.gleam
+++ b/src/gleamyshell.gleam
@@ -92,8 +92,6 @@ pub fn os() -> OsFamily
 
 /// Returns the home directory of the current user.
 /// 
-/// This function returns an `Option` because it can fail in rare circumstances.
-/// 
 /// ## Example
 /// 
 /// ```gleam


### PR DESCRIPTION
# Pull Request

Issue: #74 

## Description

This PR removes an outdated sentence in the documentation comment of `gleamyshell/home_directory`.
